### PR TITLE
Update 30_default.conf

### DIFF
--- a/etc/sdwdate.d/30_default.conf
+++ b/etc/sdwdate.d/30_default.conf
@@ -79,7 +79,6 @@ SDWDATE_POOL_ONE=(
     "http://cct5wy6mzgmft24xzw6zeaf55aaqmo6324gjlsghdhbiw5gdaaf4pkad.onion # https://web.archive.org/web/20210607181010/https://snopyta.org/"
     "https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion # https://web.archive.org/web/20210604193342/https://securityheaders.com/?q=https%3A%2F%2Fduckduckgo.com%2F&followRedirects=on"
     "https://27m3p2uv7igmj6kvd4ql3cct5h3sdwrsajovkkndeufumzyfhlfev4qd.onion # https://web.archive.org/web/20210604191739/https://securityheaders.com/?q=https%3A%2F%2Ftheintercept.com%2F&followRedirects=on"
-    "https://privacy2ws3ora5p4qpzptqr32qm54gf5ifyzvo5bhl7bb254c6nbiyd.onion # https://web.archive.org/web/20210525172238/https://securityheaders.com/?q=https%3A%2F%2Fwww.privacyinternational.org&followRedirects=on https://www.privacyinternational.org"
     "http://lxjacvxrozjlxd7pqced7dyefnbityrwqjosuuaqponlg3v7esifrzad.onion # https://web.archive.org/web/20210123173459/https://securityheaders.com/?q=securityinabox.org&followRedirects=on https://securityinabox.org/en/"
     "http://searxspbitokayvkhzhsnljde7rqmn7rvoga6e4waeub3h7ug3nghoad.onion # https://web.archive.org/web/20210525165705/https://searx.space/ https://searx.space"
     "http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion # https://web.archive.org/web/20210310145458/https://onionshare.org/onion.txt OnionShare onionshare.org"


### PR DESCRIPTION
deleting privacy2ws3ora5p4qpzptqr32qm54gf5ifyzvo5bhl7bb254c6nbiyd.onion mirror due to misconfigured TLS:

` * stderr: connect error: SOCKSHTTPSConnectionPool(host='privacy2ws3ora5p4qpzptqr32qm54gf5ifyzvo5bhl7bb254c6nbiyd.onion', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1123)')))`