### PR TITLE
Fix syscall whitelist for bookworm on x86_64

### DIFF
--- a/debian/sdwdate.postinst
+++ b/debian/sdwdate.postinst
@@ -96,12 +96,12 @@ if [[ "${arch}" =~ "arm" ]] || [[ "${arch}" =~ "aarch" ]]; then
    ## ARM-specific syscalls.
    syscall_whitelist="\
 [Service]
-SystemCallFilter=faccessat readlinkat newfstatat mkdirat dup3 ppoll pselect6 unlinkat"
+SystemCallFilter=faccessat readlinkat mkdirat dup3 ppoll pselect6 unlinkat"
 elif [[ "${arch}" =~ "ppc" ]]; then
    ## PowerPC-specific syscalls.
    syscall_whitelist="\
 [Service]
-SystemCallFilter=_llseek send waitpid recv prctl _newselect newfstatat pselect6 vfork"
+SystemCallFilter=_llseek send waitpid recv prctl _newselect pselect6"
 elif [[ "${arch}" =~ "x86" ]]; then
    syscall_whitelist="\
 ## Default. No changes required."

--- a/lib/systemd/system/sdwdate.service
+++ b/lib/systemd/system/sdwdate.service
@@ -72,7 +72,7 @@ SystemCallArchitectures=native
 ## debian/sdwdate.postinst
 ## https://github.com/Whonix/sdwdate/blob/master/debian/sdwdate.postinst
 ## https://gitlab.com/whonix/sdwdate/blob/master/debian/sdwdate.postinst
-SystemCallFilter=wait4 select futex read stat close openat fstat lseek mmap rt_sigaction getdents64 mprotect ioctl recvfrom munmap brk rt_sigprocmask fcntl getpid write access socket sendto dup2 clone execve getrandom geteuid getgid madvise getuid getegid readlink pipe rt_sigreturn connect pipe2 prlimit64 set_robust_list dup arch_prctl lstat set_tid_address sysinfo sigaltstack rt_sigsuspend shutdown timer_settime mkdir timer_create statfs getcwd setpgid setsockopt uname bind getpgrp getppid getpeername chdir poll getsockname fadvise64 clock_settime kill getsockopt unlink epoll_create1 utimensat mremap prctl sendmsg
+SystemCallFilter=wait4 select futex read stat close openat fstat lseek mmap rt_sigaction getdents64 mprotect ioctl recvfrom munmap brk rt_sigprocmask fcntl getpid write access socket sendto dup2 clone execve getrandom geteuid getgid madvise getuid getegid readlink pipe rt_sigreturn connect pipe2 prlimit64 set_robust_list dup arch_prctl lstat set_tid_address sysinfo sigaltstack rt_sigsuspend shutdown timer_settime mkdir timer_create statfs getcwd setpgid setsockopt uname bind getpgrp getppid getpeername chdir poll getsockname fadvise64 clock_settime kill getsockopt unlink epoll_create1 utimensat mremap prctl sendmsg newfstatat pread64 vfork close_range clone3 get_mempolicy set_mempolicy
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes http://forums.w5j6stm77zs6652pgsij4awcjeel3eco7kvipheu6mtr623eyyehj4yd.onion/t/sdwdate-failed-to-start-in-debian-12-bookworm-next-release/134

I haven't investigated why these syscalls are now needed, nor what attack surface they may introduce.